### PR TITLE
Update dynamic referencer to ignore roxygen comments

### DIFF
--- a/R/dynamic_referencing.R
+++ b/R/dynamic_referencing.R
@@ -229,6 +229,9 @@ dynamic_reference_rendering <- function(file, reference = NULL){
 }
 
 
+## original method from:
+## https://stackoverflow.com/questions/181596
+
 numeric_to_letter_ref <- function(x){
   col_name <- c()
 

--- a/R/dynamic_referencing.R
+++ b/R/dynamic_referencing.R
@@ -51,6 +51,9 @@ vt_dynamic_referencer <- R6::R6Class("vt_dynamic_referencer",
 
           scrape_references = function(text){
 
+            ## Drop roxygen comment headers from text for scraping references.
+            text <- text[!grepl("^#'", text)]
+
             reference_locations <-
               gregexpr(
                 paste0(
@@ -129,6 +132,8 @@ vt_dynamic_referencer <- R6::R6Class("vt_dynamic_referencer",
 
             for(ref in names(references)){
               ref_value <- references[[ref]]
+
+
               text = gsub(
                 pattern = paste0(private$reference_indicator,ref),
                 replacement = ref_value,
@@ -156,12 +161,16 @@ vt_dynamic_referencer <- R6::R6Class("vt_dynamic_referencer",
           #' create a new dynamic reference object
           #' @param reference_indicator character vector that indicates the start of the dynamic references. defaults to "##type:reference"
           #' @return a new `vt_dynamic_reference` object
-          initialize = function(reference_indicator = "##"){
+          initialize = function(reference_indicator = "##", type = c("number","letter")){
+
             private$references <- list()
+
             private$ref_iter_number <- list(
               req = 0,
               tc = 0
             )
+
+            private$type <- match.arg(type)
 
             private$reference_indicator <- reference_indicator
             private$reference_indicator_regex <- paste0("\\",strsplit(reference_indicator,"")[[1]], collapse = "")
@@ -169,6 +178,7 @@ vt_dynamic_referencer <- R6::R6Class("vt_dynamic_referencer",
           ),
 
         private = list(
+          type = NULL,
           references = list(),
           ref_iter_number = list(
             req = 0,
@@ -185,6 +195,9 @@ vt_dynamic_referencer <- R6::R6Class("vt_dynamic_referencer",
           add_reference = function(reference_id, type = c("req","tc")){
             type <- match.arg(type)
             reference_value = private$advance_reference(type)
+            if(private$type == "letter"){
+              reference_value <- numeric_to_letter_ref(reference_value)
+            }
             private$references[[reference_id]] <- reference_value
           }
         ))
@@ -215,4 +228,17 @@ dynamic_reference_rendering <- function(file, reference = NULL){
 
 }
 
+
+numeric_to_letter_ref <- function(x){
+  col_name <- c()
+
+  while(x > 0){
+    modulo <- (x) %% 26
+    col_name <- c(LETTERS[modulo], col_name)
+    x <- as.integer( (x - modulo) / 26)
+  }
+
+  paste(col_name,collapse = "")
+
+}
 

--- a/tests/testthat/test-dynamic_referencing.R
+++ b/tests/testthat/test-dynamic_referencing.R
@@ -98,6 +98,52 @@ test_that("Dynamic Number Referencer can initialize and identify patterns in mul
 
 })
 
+test_that("Dynamic Number Referencer can ignore roxygen comment lines", {
+
+  references <- vt_dynamic_referencer$new()
+  references$initialize(reference_indicator = "##")
+
+  ## Add new multi string
+  multi_line <- c("#' @test ##req:string1","text ##req:string2")
+
+  references$scrape_references(multi_line)
+
+  expect_equal(
+    names(references$list_references()),
+    c("req:string2")
+  )
+
+  ## string replacement
+  expect_equal(
+    references$reference_insertion(multi_line),
+    c("#' @test ##req:string1","text 1")
+  )
+
+})
+
+test_that("Dynamic Number Referencer can use letters as an output too!", {
+
+  references <- vt_dynamic_referencer$new()
+  references$initialize(reference_indicator = "##", type = "letter")
+
+  ## Add new multi string
+  multi_line <- c("test ##req:string1","text ##req:string2")
+
+  references$scrape_references(multi_line)
+
+  expect_equal(
+    names(references$list_references()),
+    c("req:string1","req:string2")
+  )
+
+  ## string replacement
+  expect_equal(
+    references$reference_insertion(multi_line),
+    c("test A","text B")
+  )
+
+})
+
 test_that("Dynamic Number Referencer can use any reference identifier including specials", {
 
   references <- vt_dynamic_referencer$new()
@@ -174,9 +220,9 @@ test_that("Dynamic Number Referencing Works on files", {
     "#' @section Last update date:",
     "#' 2021-02-15",
     "",
-    "#' + _Specifications_",
-    "#'   + S##req:dynamic_numbering.1 User is able to reference numbers dynamically",
-    "#'     + S##req:dynamic_numbering.1.1 Numbers will automatically update on rendering",
+    "+ _Specifications_",
+    "  + S##req:dynamic_numbering.1 User is able to reference numbers dynamically",
+    "    + S##req:dynamic_numbering.1.1 Numbers will automatically update on rendering",
     ""))
 
   cat(
@@ -191,8 +237,8 @@ test_that("Dynamic Number Referencing Works on files", {
       "#' @section Specification coverage:",
       "#' ##tc:dynamic_numbering_testcase.1: ##req:dynamic_numbering.1, ##req:dynamic_numbering.2",
       "",
-      "#' + _Test Cases_",
-      "#'   + T##tc:dynamic_numbering_testcase.1 Create a sample spec with a unique reference number. Ensure the output matches 1 on rendering",
+      "+ _Test Cases_",
+      "  + T##tc:dynamic_numbering_testcase.1 Create a sample spec with a unique reference number. Ensure the output matches 1 on rendering",
       ""))
 
   cat(
@@ -233,9 +279,9 @@ test_that("Dynamic Number Referencing Works on files", {
       "#' @section Last update date:",
       "#' 2021-02-15",
       "",
-      "#' + _Specifications_",
-      "#'   + S1.1 User is able to reference numbers dynamically",
-      "#'     + S1.1.1 Numbers will automatically update on rendering",
+      "+ _Specifications_",
+      "  + S1.1 User is able to reference numbers dynamically",
+      "    + S1.1.1 Numbers will automatically update on rendering",
       ""))
 
   expect_equal(
@@ -249,8 +295,8 @@ test_that("Dynamic Number Referencing Works on files", {
       "#' @section Specification coverage:",
       "#' 1.1: 1.1, 1.2",
       "",
-      "#' + _Test Cases_",
-      "#'   + T1.1 Create a sample spec with a unique reference number. Ensure the output matches 1 on rendering",
+      "+ _Test Cases_",
+      "  + T1.1 Create a sample spec with a unique reference number. Ensure the output matches 1 on rendering",
       ""))
 
   expect_equal(
@@ -270,8 +316,6 @@ test_that("Dynamic Number Referencing Works on files", {
 
 
 test_that("Dynamic Number Referencing across rmarkdown chunks", {
-  # need to alter test such that does not need `valtools` installed to test
-  # if(FALSE){
 
   ## Create test files
   test_req1 <- tempfile(fileext = ".md")
@@ -327,29 +371,30 @@ test_that("Dynamic Number Referencing across rmarkdown chunks", {
       '```',
       '\n\n',
       '```{r require-1, echo=FALSE}',
-      'dynamic_reference_rendering(',
+      'cat(dynamic_reference_rendering(',
       paste0('  file = "', gsub(pattern = "\\\\",
                                 replacement = "\\\\\\\\",
                                 normalizePath(test_req1)), '",'),
       '  reference = test_referencer',
-      ')',
+      '),sep = "\\n")',
       '```',
       '\n\n',
       '```{r require-2, echo=FALSE}',
-      'dynamic_reference_rendering(',
+      'cat(dynamic_reference_rendering(',
       paste0('  file = "', gsub(pattern = "\\\\",
                                 replacement = "\\\\\\\\",
                                 normalizePath(test_req2)), '",'),
       '  reference = test_referencer',
-      ')',
+      '),sep = "\\n")',
       '```'
 
 
       ))
 
+  suppressWarnings({
   quiet <- capture.output({
-  rmarkdown::render(input = test_report, clean = FALSE)
-  })
+  rmarkdown::render(input = test_report, clean = FALSE, quiet = TRUE)
+  })})
 
   test_output_rendered <-
     readLines(gsub(test_report, pattern = ".Rmd", replacement = ".knit.md"))
@@ -378,29 +423,27 @@ test_that("Dynamic Number Referencing across rmarkdown chunks", {
     "",
     "",
     "```",
-    "## [1] \"#' @title Test Requirement 1\"                               ",
-    "## [2] \"#' @editor An Author\"                                       ",
-    "## [3] \"#' @editDate 2021-02-15\"                                    ",
-    "## [4] \"\"                                                           ",
-    "## [5] \"+ _Requirements_\"                                           ",
-    "## [6] \"  + S1.1 User is able to reference numbers dynamically\"     ",
-    "## [7] \"    + S1.1.1 Numbers will automatically update on rendering\"",
-    "## [8] \"\"",
+    "## #' @title Test Requirement 1",
+    "## #' @editor An Author",
+    "## #' @editDate 2021-02-15",
+    "## ",
+    "## + _Requirements_",
+    "##   + S1.1 User is able to reference numbers dynamically",
+    "##     + S1.1.1 Numbers will automatically update on rendering",
     "```",
     "",
     "",
     "",
     "",
     "```",
-    "## [1] \"#' @title Test Requirement 2\"                                ",
-    "## [2] \"#' @editor Another Author\"                                   ",
-    "## [3] \"#' @editDate 2021-02-20\"                                     ",
-    "## [4] \"\"                                                            ",
-    "## [5] \"+ _Requirements_\"                                            ",
-    "## [6] \"  + S2.1 User is able to reference numbers dynamically\"      ",
-    "## [7] \"     + S2.1.1 Numbers will automatically update on rendering\"",
-    "## [8] \"\"",
+    "## #' @title Test Requirement 2",
+    "## #' @editor Another Author",
+    "## #' @editDate 2021-02-20",
+    "## ",
+    "## + _Requirements_",
+    "##   + S2.1 User is able to reference numbers dynamically",
+    "##      + S2.1.1 Numbers will automatically update on rendering",
     "```"
   ))
-# }
+
 })

--- a/tests/testthat/test-latex_dynamic_referencing.R
+++ b/tests/testthat/test-latex_dynamic_referencing.R
@@ -65,9 +65,10 @@ test_that("latex Number Referencing across rmarkdown chunks", {
 
     ))
 
+  suppressWarnings({
   quiet <- capture.output({
-    test_output <- rmarkdown::render(input = test_report, clean = FALSE)
-  })
+    test_output <- rmarkdown::render(input = test_report, clean = FALSE, quiet = TRUE)
+  })})
 
 
   test_output_rendered <-trimws(strsplit(split = "\r\n",gsub("((\r)|(\n))+","\r\n",
@@ -156,9 +157,13 @@ test_that("latex Number Referencing across rmarkdown chunks", {
         'keep_tex: yes'
 
     ))
+
   setwd(dirname(test_report))
 
-  bookdown::render_book(basename(test_report))
+  suppressWarnings({
+  quiet <- capture_output({
+  bookdown::render_book(basename(test_report), quiet = TRUE,)
+  })})
 
   pdf_report_name <- file.path(dirname(test_report),
                                "docs",
@@ -175,11 +180,6 @@ test_that("latex Number Referencing across rmarkdown chunks", {
   expect_equal("2", substr(test_output_rendered[6], 1, 1))
   expect_equal("S2.1", substr(trimws(test_output_rendered[8]), 3, 6))
   expect_equal("S2.1.1", substr(trimws(test_output_rendered[9]), 3, 8))
-
-
-
-
-
 
 })
 })


### PR DESCRIPTION
Update dynamic referencer
- ignores roxygen comments when determining the referencing to use
- Added ability to use letters instead of numbers to referencer