### PR TITLE
fixes #69

### DIFF
--- a/R/roxygen_extension.R
+++ b/R/roxygen_extension.R
@@ -16,6 +16,7 @@ roxy_tag_parse.roxy_tag_editDate <- function(x) {
 #' @importFrom lubridate parse_date_time
 #' @importFrom roxygen2  roxy_tag_parse
 roxy_tag_parse.roxy_tag_coverage<- function(x) {
+
   x <- format_coverage_text(x)
 }
 
@@ -60,7 +61,6 @@ format.rd_section_coverage <- function(x, ...) {
 }
 
 format_coverage_text <- function(x){
-
   ## capture val
   x <- tag_markdown(x)
 
@@ -69,7 +69,7 @@ format_coverage_text <- function(x){
   test_coverage <- strsplit(text, "\n")
 
   coverage <- lapply(
-    test_coverage,
+    test_coverage[[1]],
     function(tc){
       if(grepl("deprecate", tc, ignore.case = TRUE)){
         data.frame(

--- a/tests/testthat/test-roxygen_extension.R
+++ b/tests/testthat/test-roxygen_extension.R
@@ -111,3 +111,21 @@ test_that("Roxygen can read in new tags - DD-MMMM-YYYY", {
   )
 
 })
+
+
+test_that("formatting coverage section parses correctly", {
+    # one test case
+    cov_tag1 <- roxygen2::roxy_tag(tag = "coverage",
+                                raw = "1.1: 1.1, 1.2")
+    expect_s3_class(class = "roxy_tag_coverage",
+                 format_coverage_text(cov_tag1))
+
+    # multiple test cases
+    cov_tag2 <- roxygen2::roxy_tag(tag = "coverage",
+                                       raw = "\n1.1: 1.1, 1.2\n1.2: 1.2, 1.3\n1.3: 1.1, 1.3, 1.4",
+                                       line = 4)
+    expect_s3_class(class = "roxy_tag_coverage",
+                    format_coverage_text(cov_tag2))
+
+
+})


### PR DESCRIPTION
strsplit returns list same length as input, so need to cycle through vector of [[1]], not the list.