### PR TITLE
extend dynamic referencing for data.frame

### DIFF
--- a/R/dynamic_referencing.R
+++ b/R/dynamic_referencing.R
@@ -52,7 +52,7 @@ vt_dynamic_referencer <- R6::R6Class("vt_dynamic_referencer",
           scrape_references = function(text){
 
             ## Drop roxygen comment headers from text for scraping references.
-            text <- text[!grepl("^#'", text)]
+            text <- unname(unlist(text[!grepl("^#'", text)]))
 
             reference_locations <-
               gregexpr(
@@ -133,13 +133,21 @@ vt_dynamic_referencer <- R6::R6Class("vt_dynamic_referencer",
             for(ref in names(references)){
               ref_value <- references[[ref]]
 
+              if("data.frame" %in% class(text)){
+                text <- as.data.frame(lapply(text, gsub,
+                                             pattern = paste0(private$reference_indicator, ref),
+                                             replacement = ref_value,
+                                             fixed = TRUE))
+              } else {
+                text <- gsub(
+                  pattern = paste0(private$reference_indicator,ref),
+                  replacement = ref_value,
+                  text,
+                  fixed = TRUE,
+                )
+              }
 
-              text = gsub(
-                pattern = paste0(private$reference_indicator,ref),
-                replacement = ref_value,
-                text,
-                fixed = TRUE,
-              )
+
             }
 
             text

--- a/tests/testthat/test-dynamic_referencing.R
+++ b/tests/testthat/test-dynamic_referencing.R
@@ -447,3 +447,21 @@ test_that("Dynamic Number Referencing across rmarkdown chunks", {
   ))
 
 })
+
+test_that("Dynaming referencing within a data.frame",{
+
+  cov_matrix_content <- data.frame( req_id = "##req:first",
+                                    tc_id = c("##tc:first", "##tc:second"))
+
+  references <- vt_dynamic_referencer$new()
+  references$initialize(reference_indicator = "##")
+  references$scrape_references(cov_matrix_content)
+  expect_equal(references$reference_insertion(cov_matrix_content),
+               data.frame(req_id = "1",
+                          tc_id = c("1", "2")))
+
+  expect_equal(references$reference_insertion(cov_matrix_content$tc_id),
+               c("1", "2"))
+
+
+})


### PR DESCRIPTION
allows for use case described here: https://github.com/phuse-org/valtools/issues/71#issuecomment-802003601

This is a rather brute-force implementation. A more robust approach would be to dispatch the gsub call as a generic function, but not sure if we want that much overhead.