### PR TITLE
Config finder hotfix

### DIFF
--- a/R/file_and_path_utils.R
+++ b/R/file_and_path_utils.R
@@ -121,7 +121,7 @@ find_file <- function(filename, ref = ".", full_names = FALSE){
 
 
     if (full_names) {
-      file_path <- c(ref, fp)
+      fp <- c(ref, fp)
     }
 
     fp <- do.call('file.path', fp)
@@ -136,23 +136,20 @@ find_file <- function(filename, ref = ".", full_names = FALSE){
 ## it is source by whether it lives in the "Working" or "output" dir
 ## if not interactive, select file that is within the wd
 config_selector <- function(files){
-  if(interactive()){
-  files[sapply(
-    files,
-    function(config_file){
-      config_file_path <- split_path()
-      config_paths <- read_yaml(config_file)
-      if(dirs$working_dir %in% config_file_path){
-        TRUE
-      }else{
-        FALSE
-      }
-    })]
-  }else{
-
-    wd<- do.call('file.path',as.list(split_path(getwd())))
-    files[grepl(wd,normalizePath(files, winslash = "/"), fixed = TRUE)
-
+  if (interactive()) {
+    files[sapply(files,
+                 function(config_file) {
+                   dirs <- read_yaml(config_file)
+                   wd <- do.call('file.path', as.list(split_path(dirs$working_dir)))
+                   if (grepl(wd, config_file, fixed = TRUE)) {
+                     TRUE
+                   } else{
+                     FALSE
+                   }
+                 })]
+  } else{
+    wd <- do.call('file.path', as.list(split_path(getwd())))
+    files[grepl(wd, normalizePath(files, winslash = "/"), fixed = TRUE)]
   }
 }
 

--- a/R/file_and_path_utils.R
+++ b/R/file_and_path_utils.R
@@ -132,11 +132,10 @@ find_file <- function(filename, ref = ".", full_names = FALSE){
 
 
 
-## read both config files, determine if one is the "source" -
+## if interactive, read both config files, determine if one is the "source" -
 ## it is source by whether it lives in the "Working" or "output" dir
+## if not interactive, select file that is within the wd
 config_selector <- function(files){
-
-
   if(interactive()){
   files[sapply(
     files,
@@ -152,9 +151,7 @@ config_selector <- function(files){
   }else{
 
     wd<- do.call('file.path',as.list(split_path(getwd())))
-
     files[grepl(wd,normalizePath(files, winslash = "/"), fixed = TRUE)
-
 
   }
 }

--- a/R/file_and_path_utils.R
+++ b/R/file_and_path_utils.R
@@ -135,8 +135,8 @@ find_file <- function(filename, ref = ".", full_names = FALSE){
 ## if interactive, read both config files, determine if one is the "source" -
 ## it is source by whether it lives in the "Working" or "output" dir
 ## if not interactive, select file that is within the wd
-config_selector <- function(files){
-  if (interactive()) {
+config_selector <- function(files, interactive = interactive()){
+  if (interactive) {
     files[sapply(files,
                  function(config_file) {
                    dirs <- read_yaml(config_file)
@@ -149,7 +149,11 @@ config_selector <- function(files){
                  })]
   } else{
     wd <- do.call('file.path', as.list(split_path(getwd())))
-    files[grepl(wd, normalizePath(files, winslash = "/"), fixed = TRUE)]
+    files <- files[grepl(wd, normalizePath(files, winslash = "/"), fixed = TRUE)]
+    if(length(files) > 1){
+      files <- files[which.min(sapply(files, function(p){length(split_path(p))}))]
+    }
+    files
   }
 }
 

--- a/tests/testthat/test-config_selector.R
+++ b/tests/testthat/test-config_selector.R
@@ -1,0 +1,66 @@
+test_that("ensure the correct config is selected when not interactive", {
+  withr::with_tempdir({
+
+    quiet <- capture.output({
+      valtools::vt_create_package()
+    })
+
+    dir.create("inst/validation/",recursive = TRUE)
+    file.copy("vignettes/validation/validation.yml",to = "inst/validation")
+
+    withr::with_dir("vignettes", {
+      expect_equal(
+        config_selector(normalizePath(
+          find_file("validation.yml", ref = "..", full_names = TRUE),
+          winslash = "/"
+        ),
+        interactive = FALSE),
+        normalizePath(file.path(getwd(), "validation/validation.yml"),
+                      winslash = "/")
+      )
+
+    })
+
+
+    ## config_selector changes behavior when not interactive to select whichever validation.yml is in the same path & closest
+    withr::with_dir("inst", {
+      expect_equal(
+        config_selector(normalizePath(
+          find_file("validation.yml", ref = "..", full_names = TRUE),
+          winslash = "/"
+        ),
+        interactive = FALSE),
+        normalizePath(file.path(getwd(), "validation/validation.yml"),
+                      winslash = "/")
+      )
+
+    })
+
+    dir.create("inst/validation/nested")
+    file.copy("inst/validation/validation.yml",to = "inst/validation/nested/validation.yml")
+
+    ## config_selector changes behavior when not interactive to select whichever validation.yml is in the same path & closest
+    withr::with_dir("inst", {
+      expect_true(all(
+        find_file("validation.yml", ref = ".", full_names = TRUE) %in%
+          c(
+            "./validation/validation.yml",
+            "./validation/nested/validation.yml"
+          )
+      ))
+
+      expect_equal(
+        config_selector(normalizePath(
+          find_file("validation.yml", ref = "..", full_names = TRUE),
+          winslash = "/"
+        ),
+        interactive = FALSE),
+        normalizePath(file.path(getwd(), "validation/validation.yml"),
+                      winslash = "/")
+      )
+
+    })
+
+  })
+
+})

--- a/tests/testthat/test-find_file.R
+++ b/tests/testthat/test-find_file.R
@@ -1,0 +1,93 @@
+test_that("finding a file works", {
+  withr::with_tempdir({
+
+    ## create folders
+    dir.create("folder1/folder2/folder3",recursive = TRUE)
+    file.create("folder1/folder2/folder3/hello.R")
+
+    expect_equal(
+      find_file("hello.R"),
+      "folder1/folder2/folder3/hello.R"
+    )
+
+  })
+})
+
+test_that("finding a file works relative to reference", {
+  withr::with_tempdir({
+
+    ## create folders
+    dir.create("folder1/folder2/folder3",recursive = TRUE)
+    file.create("folder1/folder2/folder3/hello.R")
+
+    expect_equal(
+      find_file("hello.R", ref = "folder1/folder2"),
+      "folder3/hello.R"
+    )
+
+  })
+})
+
+test_that("finding a file can return multiple files", {
+  withr::with_tempdir({
+
+    ## create folders
+    dir.create("folder1/folder2/folder3",recursive = TRUE)
+    file.create("folder1/folder2/folder3/hello.R")
+    file.create("folder1/folder2/hello.R")
+
+    expect_true(
+      all(c(
+        "folder1/folder2/hello.R",
+        "folder1/folder2/folder3/hello.R"
+      ) %in%
+      find_file("hello.R")
+    ))
+
+  })
+})
+
+test_that("when finding multiple files a preference can be stated", {
+  withr::with_tempdir({
+
+    ## create folders
+    dir.create("folder1/folder2/folder3",recursive = TRUE)
+    dir.create("folder4/folder5/folder6",recursive = TRUE)
+    file.create("folder1/folder2/folder3/hello.R")
+    file.create("folder1/folder2/hello.R")
+    file.create("folder4/folder5/folder6/hello.R")
+
+    expect_equal(
+        find_file("hello.R", preference = "folder4"),
+        "folder4/folder5/folder6/hello.R"
+    )
+
+    expect_equal(
+      find_file("hello.R", preference = "folder5"),
+      "folder4/folder5/folder6/hello.R"
+    )
+
+    expect_equal(
+      find_file("hello.R", preference = "folder6"),
+      "folder4/folder5/folder6/hello.R"
+    )
+
+    expect_equal(
+      find_file("hello.R", preference = "folder2/folder3"),
+      "folder1/folder2/folder3/hello.R"
+    )
+
+    expect_equal(
+      find_file("hello.R", preference = "folder2"),
+      c(
+        "folder1/folder2/folder3/hello.R",
+        "folder1/folder2/hello.R"
+      )
+    )
+
+  })
+})
+
+
+
+

--- a/tests/testthat/test-find_file.R
+++ b/tests/testthat/test-find_file.R
@@ -47,47 +47,6 @@ test_that("finding a file can return multiple files", {
   })
 })
 
-test_that("when finding multiple files a preference can be stated", {
-  withr::with_tempdir({
-
-    ## create folders
-    dir.create("folder1/folder2/folder3",recursive = TRUE)
-    dir.create("folder4/folder5/folder6",recursive = TRUE)
-    file.create("folder1/folder2/folder3/hello.R")
-    file.create("folder1/folder2/hello.R")
-    file.create("folder4/folder5/folder6/hello.R")
-
-    expect_equal(
-        find_file("hello.R", preference = "folder4"),
-        "folder4/folder5/folder6/hello.R"
-    )
-
-    expect_equal(
-      find_file("hello.R", preference = "folder5"),
-      "folder4/folder5/folder6/hello.R"
-    )
-
-    expect_equal(
-      find_file("hello.R", preference = "folder6"),
-      "folder4/folder5/folder6/hello.R"
-    )
-
-    expect_equal(
-      find_file("hello.R", preference = "folder2/folder3"),
-      "folder1/folder2/folder3/hello.R"
-    )
-
-    expect_equal(
-      find_file("hello.R", preference = "folder2"),
-      c(
-        "folder1/folder2/folder3/hello.R",
-        "folder1/folder2/hello.R"
-      )
-    )
-
-  })
-})
-
 
 
 


### PR DESCRIPTION
identified a bug in the original logic when:
- validation.yml exists in working dir
- validation.yml has been copied into output dir

then trying to rerun validation code, it isnt sure which to pick. 

Code now has a "config_selector" function that selects:
- if interactive, selects the one in the working dir. 
- if not interative, selects one closest to current dir (ie if knitting rmd, will select closest validation.yml (assumes in child folder))