### PR TITLE
promise errors in config_selector

### DIFF
--- a/R/file_and_path_utils.R
+++ b/R/file_and_path_utils.R
@@ -135,8 +135,9 @@ find_file <- function(filename, ref = ".", full_names = FALSE){
 ## if interactive, read both config files, determine if one is the "source" -
 ## it is source by whether it lives in the "Working" or "output" dir
 ## if not interactive, select file that is within the wd
-config_selector <- function(files, interactive = interactive()){
-  if (interactive) {
+config_selector <- function(files, is_live = interactive()){
+  if (is_live) {
+
     files[sapply(files,
                  function(config_file) {
                    dirs <- read_yaml(config_file)

--- a/tests/testthat/test-config_selector.R
+++ b/tests/testthat/test-config_selector.R
@@ -14,7 +14,7 @@ test_that("ensure the correct config is selected when not interactive", {
           find_file("validation.yml", ref = "..", full_names = TRUE),
           winslash = "/"
         ),
-        interactive = FALSE),
+        is_live = FALSE),
         normalizePath(file.path(getwd(), "validation/validation.yml"),
                       winslash = "/")
       )
@@ -29,7 +29,7 @@ test_that("ensure the correct config is selected when not interactive", {
           find_file("validation.yml", ref = "..", full_names = TRUE),
           winslash = "/"
         ),
-        interactive = FALSE),
+        is_live = FALSE),
         normalizePath(file.path(getwd(), "validation/validation.yml"),
                       winslash = "/")
       )
@@ -54,7 +54,7 @@ test_that("ensure the correct config is selected when not interactive", {
           find_file("validation.yml", ref = "..", full_names = TRUE),
           winslash = "/"
         ),
-        interactive = FALSE),
+        is_live = FALSE),
         normalizePath(file.path(getwd(), "validation/validation.yml"),
                       winslash = "/")
       )


### PR DESCRIPTION
unintentionally was using interactive as an argument - changed to `is_live`

was running into errors due to unintentionally using "interactive" as an argument & input, which led to strange behavior. updated to "is_live", really doesn't impact much since it is an internal function. 