### PR TITLE
Fix spacing bug following : in legacy section usage

### DIFF
--- a/R/parse_roxygen.R
+++ b/R/parse_roxygen.R
@@ -293,7 +293,7 @@ cleanup_section_last_update <- function(blocks){
       section_tags <- block_get_tags(block = block, tags = "section")
 
       content <- do.call('c',lapply(section_tags, function(tags){
-        section_split <- strsplit(tags[["val"]],":\n",fixed = TRUE)[[1]]
+        section_split <- strsplit(tags[["val"]],"[:]\\s*\\n")[[1]]
         selection <- section_split[[2]]
         names(selection) <- section_split[[1]]
         selection

--- a/tests/testthat/test-parse_roxygen.R
+++ b/tests/testthat/test-parse_roxygen.R
@@ -136,8 +136,27 @@ test_that("parsing R function files with old nomenclature as expected", {
     ",
     class = "r")
 
+  ## This example has trailing spaces after the ":"
+  file_content_trailing_spaces <- structure(paste(c(
+   "#' @title sample title:",
+   "#' @section last updated by:  ",
+   "#' Sample Editor",
+   "#' @section last update date:  ",
+   "#' 1900-01-01",
+   "#' @param name name printed",
+   "#' @export",
+   "#' @rdname test",
+   "hello_world <- function(name){",
+   "  print(\"hello,\",name)",
+   "}"),collapse = "\n"),
+    class = "r")
+
   warnings <- capture_warnings({
     block_list <- parse_roxygen(file_content)
+  })
+
+  warnings_trailing <- capture_warnings({
+    block_list_trailing <- parse_roxygen(file_content_trailing_spaces)
   })
 
   expect_equal(
@@ -146,7 +165,17 @@ test_that("parsing R function files with old nomenclature as expected", {
   )
 
   expect_equal(
+    roxygen2::block_get_tag(block_list_trailing[[1]],"editor")$val,
+    "Sample Editor"
+  )
+
+  expect_equal(
     roxygen2::block_get_tag(block_list[[1]],"editDate")$val,
+    "1900-01-01"
+  )
+
+  expect_equal(
+    roxygen2::block_get_tag(block_list_trailing[[1]],"editDate")$val,
     "1900-01-01"
   )
 
@@ -157,6 +186,15 @@ test_that("parsing R function files with old nomenclature as expected", {
     "`@section last update date:` is superseded.\nUse `@editDate 1900-01-01` instead."
     )
   )
+
+  expect_equal(
+    warnings_trailing,
+    c(
+      "`@section last updated by:` is superseded.\nUse `@editor Sample Editor` instead.",
+      "`@section last update date:` is superseded.\nUse `@editDate 1900-01-01` instead."
+    )
+  )
+
 })
 
 test_that("parsing R test code files as expected", {


### PR DESCRIPTION
resolves #144 - regex was written to strict.

Updated regex and added test for trailing spaces.