### PR TITLE
Add tests for `render_template()` function

### DIFF
--- a/R/template.R
+++ b/R/template.R
@@ -39,8 +39,8 @@ render_template <- function(template, output = template, data = list()){
     )
 
   }, error = function(e) {
-    abort(paste0(c("Error during creation of template `",template,"`. Error: ",
-                   e, sep = "\n")),
+    abort(paste0(c(paste0("Error during creation of template `",template,"`. Error: "),
+                   e), sep = "\n"),
           class = "vt.template_render_fail")
   })
 

--- a/tests/testthat/test-render_template.R
+++ b/tests/testthat/test-render_template.R
@@ -1,0 +1,58 @@
+test_that("explicit template testing - success", {
+  withr::with_tempdir({
+
+    template_success <- render_template(template = "requirements",
+                    output = "req_template_output.md",
+                    data = list(
+                      title = "TEST TITLE",
+                      username = "USERNAME",
+                      editDate = "DATE"
+                    ))
+
+    expect_equal(
+      readLines("req_template_output.md"),
+      c("#' @title TEST TITLE",
+        "#' @editor USERNAME",
+        "#' @editDate DATE",
+        "#' @riskAssessment",
+        "#' REQUIREMENT: ASSESSMENT",
+        "",
+        "+ Start documenting requirements here!",
+        "")
+    )
+
+  })
+
+})
+
+test_that("explicit template testing - warning&error - bad path", {
+
+  withr::with_tempdir({
+    expect_warning(
+    expect_error(
+      render_template(
+        template = "requirements",
+        output = "new/file/path/req_template_output.md",
+        data = list(title = "TEST TITLE",
+                    username = "USERNAME",
+                    date = "DATE")
+      ),
+      "Error during creation of template `requirements`. Error:")
+    )
+  })
+})
+
+test_that("explicit template testing - failure - template does not exist", {
+
+  withr::with_tempdir({
+
+    expect_error(
+      render_template(
+        template = "TEMPLATE DNE",
+        output = "req_template_output.md"
+      ),
+      "Template `TEMPLATE DNE` does not exist[.]"
+    )
+  })
+
+})


### PR DESCRIPTION
Realized the function was not being explicitly tested. 

Found issue with and correct error message output when creation of template fails

Add tests for render_template - hit both "aborts" and a simple success case