### PR TITLE
Stop create_item from overwriting

### DIFF
--- a/R/case.R
+++ b/R/case.R
@@ -60,11 +60,14 @@ vt_use_test_case <- function(name, username = vt_username(), title = NULL, open 
                        username = username,
                        editDate = as.character(Sys.Date())
                      ))
-
+    
+    # Add file to validation configuration
+    vt_add_file_to_config(
+      filename = name,
+      after = {{add_after}},
+      before = {{add_before}}
+      )
   }
-
-  # Add file to validation configuration
-  vt_add_file_to_config(filename = name, after = {{add_after}}, before = {{add_before}})
 
   if(open){
     edit_file(case_name)

--- a/R/code.R
+++ b/R/code.R
@@ -20,11 +20,16 @@ vt_use_test_code <- function(name, username = vt_username(), open = interactive(
                       username = username,
                       editDate = as.character(Sys.Date())
                     ))
+    
+    # Add file to validation configuration
+    vt_add_file_to_config(
+      filename = name,
+      after = {{add_after}},
+      before = {{add_before}}
+      )
   }
 
-  # Add file to validation configuration
-  vt_add_file_to_config(filename = name, after = {{add_after}},
-                        before = {{add_before}})
+
 
   if(open){
     edit_file(code_name)

--- a/R/req.R
+++ b/R/req.R
@@ -29,9 +29,14 @@ vt_use_req <- function(name, username = vt_username(), title = NULL, open = inte
                       title = title,
                       editDate = as.character(Sys.Date())
                     ))
+    
+    vt_add_file_to_config(
+      filename = name,
+      after = {{add_after}},
+      before = {{add_before}}
+      )
   }
 
-  vt_add_file_to_config(filename = name, after = {{add_after}}, before = {{add_before}})
 
   if(open){
     edit_file(req_name)

--- a/R/utils.R
+++ b/R/utils.R
@@ -13,6 +13,13 @@ create_item <- function(type = c("requirements","test_cases","test_code"), item_
   type <- match.arg(type)
 
   validation_directory <- vt_path()
+  
+  item_file_path <- file.path(validation_directory, type, item_name)
+  
+  ## if file exists, just return path
+  if(file.exists(item_file_path)){
+    return(item_file_path)
+  }
 
   # Create item folder if this is the first item
   if(!dir.exists(file.path(validation_directory, type))) {
@@ -35,19 +42,29 @@ create_item <- function(type = c("requirements","test_cases","test_code"), item_
     })
   }
 
-  item_file_path <- file.path(validation_directory, type, item_name)
+
 
   tryCatch({
-
     file.create(item_file_path)
-    inform(paste0("Item created:", file.path(type, item_name), sep = " ", collapse = ""))
+    inform(paste0(
+      "Item created:",
+      file.path(type, item_name),
+      sep = " ",
+      collapse = ""
+    ))
     return(item_file_path)
-
+    
   }, error = function(e) {
-    abort(paste0("Failed to create validation", type, item_name,
-                                  sep = " ", collapse = ""),
-                           class = "vt.itemCreateFail")
+    abort(paste0(
+      "Failed to create validation",
+      type,
+      item_name,
+      sep = " ",
+      collapse = ""
+    ),
+    class = "vt.itemCreateFail")
   })
+  
 
 
 }

--- a/tests/testthat/test-create_item.R
+++ b/tests/testthat/test-create_item.R
@@ -108,3 +108,32 @@ test_that("Throw an error if the validation directory has not been set up", {
     )
   })
 })
+
+test_that("simple item creation does not overwrite file", {
+  withr::with_tempdir({
+    # set up "validation" infrastructure
+    dir.create("vignettes/validation", recursive = TRUE)
+    writeLines(c("working_dir: vignettes"),"vignettes/validation/validation.yml")
+    file.create(".here")
+    
+    
+    spec_path <- create_item(
+      item_name = "new_specification",
+      type = "requirements")
+    
+    spec_path_file_info <- file.info(spec_path)
+
+    
+    spec_path <- create_item(
+      item_name = "new_specification",
+      type = "requirements")
+    
+    spec_path_file_info_2 <- file.info(spec_path)
+    
+    expect_equal(
+      spec_path_file_info[,c("mtime","ctime")],
+      spec_path_file_info_2[,c("mtime","ctime")]
+    )
+  })
+})
+


### PR DESCRIPTION
This now has create_item check before it attempts to create a file that it exists. If it does exist, it just returns the path. (addresses #156)

Additionally edited vt_use_(req/test_case/test_code) to move the addition to the validation.yml into within the adding the template to the file so when we do call create_item on a file that already exists, it just opens the file with no warning.