### PR TITLE
Out of project warnings

### DIFF
--- a/R/file_and_path_utils.R
+++ b/R/file_and_path_utils.R
@@ -58,8 +58,18 @@ vt_path <- function(...){
 #'
 #' @export
 vt_find_config <- function(){
-
-  root <- find_root(has_file(".here") | is_rstudio_project | is_r_package | is_vcs_root)
+  
+  tryCatch({
+    root <- find_root(has_file(".here") | is_rstudio_project | is_r_package | is_vcs_root)
+  }, error = function(e){
+    abort(
+      paste0(
+      "Could not find root directory found. ",
+      "Is your working directory inside a package, validation packet, or project?\n"
+      ),
+      class = "vt.validation_root_missing"
+    )
+  })
 
   tryCatch({
 

--- a/R/file_and_path_utils.R
+++ b/R/file_and_path_utils.R
@@ -64,7 +64,7 @@ vt_find_config <- function(){
   }, error = function(e){
     abort(
       paste0(
-      "Could not find root directory found. ",
+      "Could not find root directory. ",
       "Is your working directory inside a package, validation packet, or project?\n"
       ),
       class = "vt.validation_root_missing"

--- a/tests/testthat/test-find_config.R
+++ b/tests/testthat/test-find_config.R
@@ -11,7 +11,7 @@ test_that("Find config when within a package with validation", {
     withr::with_dir(new = "example.package", {
       expect_equal(
         vt_find_config(),
-        file.path(getwd(), "vignettes","validation","validation.yml")
+        normalizePath(file.path(getwd(), "vignettes","validation","validation.yml"),winslash = "/")
       )
     })
   })
@@ -31,7 +31,9 @@ test_that("Find config when within a package with validation when working dir is
     withr::with_dir(new = "example.package", {
       expect_equal(
         vt_find_config(),
-        file.path(getwd(), "inst","validation","validation.yml")
+        normalizePath(
+          file.path(getwd(), "inst","validation","validation.yml"),
+          winslash = "/")
       )
     })
   })
@@ -50,7 +52,9 @@ test_that("Find config when within a validation packet", {
       withr::with_dir(new = "example_packet", {
         expect_equal(
           vt_find_config(),
-          file.path(getwd(), "validation","validation.yml")
+          normalizePath(
+            file.path(getwd(), "validation","validation.yml"),
+            winslash = "/")
         )
       })
 

--- a/tests/testthat/test-find_config.R
+++ b/tests/testthat/test-find_config.R
@@ -66,7 +66,7 @@ test_that("Informative error when outside a packet or package", {
     expect_error(
       vt_find_config(),
       paste0(
-      "Could not find root directory found. ",
+      "Could not find root directory. ",
       "Is your working directory inside a package, validation packet, or project?\n"
       ),
       fixed = TRUE)

--- a/tests/testthat/test-find_config.R
+++ b/tests/testthat/test-find_config.R
@@ -1,0 +1,76 @@
+test_that("Find config when within a package with validation", {
+  
+  withr::with_tempdir({
+    quiet <- capture.output({
+      vt_create_package(
+        "example.package", 
+        open = FALSE)
+    })
+    
+    
+    withr::with_dir(new = "example.package", {
+      expect_equal(
+        vt_find_config(),
+        file.path(getwd(), "vignettes","validation","validation.yml")
+      )
+    })
+  })
+})
+
+test_that("Find config when within a package with validation when working dir is non-standard", {
+  
+  withr::with_tempdir({
+    quiet <- capture.output({
+      vt_create_package(
+        "example.package", 
+        working_dir = "inst",
+        open = FALSE)
+    })
+    
+    
+    withr::with_dir(new = "example.package", {
+      expect_equal(
+        vt_find_config(),
+        file.path(getwd(), "inst","validation","validation.yml")
+      )
+    })
+  })
+})
+
+test_that("Find config when within a validation packet", {
+  
+  withr::with_tempdir({
+      quiet <- capture.output({
+        vt_create_packet("example_packet", 
+                         target = "example.package",
+                         open = FALSE)
+      })
+      
+      
+      withr::with_dir(new = "example_packet", {
+        expect_equal(
+          vt_find_config(),
+          file.path(getwd(), "validation","validation.yml")
+        )
+      })
+
+  })
+  
+})
+
+
+test_that("Informative error when outside a packet or package", {
+  
+  withr::with_tempdir({
+    
+    expect_error(
+      vt_find_config(),
+      paste0(
+      "Could not find root directory found. ",
+      "Is your working directory inside a package, validation packet, or project?\n"
+      ),
+      fixed = TRUE)
+  })
+  
+})
+


### PR DESCRIPTION
Should resolve #204 - 
issue is when you try to run a function dependent on finding the config file outside a package/packet, the error message is not intuitive.