### PR TITLE
Fixed error with tables when test cases fail.

### DIFF
--- a/R/evaluate_test_code.R
+++ b/R/evaluate_test_code.R
@@ -56,6 +56,9 @@ vt_kable_test_code_results <- function(results, format = vt_render_to()) {
 
   x <- results[, c("Test", "Results", "Pass_Fail")]
   colnames(x) <- c("Test", "Results", "Pass/Fail")
+  if (nrow(x) > 0) {
+    x$Results <- gsub("\n","",x$Results)
+  }
 
   t <- kable(x,format = format)
 


### PR DESCRIPTION
Fixed a bug that made it impossible to render tables whenever test cases fail. Before, pdflatex would fail with error message "Extra alignment tab has been changed to \cr. `expected`: TRUE & Fail &".