### PR TITLE
Non-integer requirement name in coverage matrix

### DIFF
--- a/R/coverage-matrix.R
+++ b/R/coverage-matrix.R
@@ -50,8 +50,8 @@ vt_scrape_coverage_matrix <- function(type = c("long", "wide"),
     # req_title uses only first numeric position
     out$req_title <- factor(out$req_title,
                             levels = paste0("Requirement ", 
-                                            sort(as.numeric(unique(unlist(lapply(strsplit(out$req_title, split = " "), 
-                                                        function(x){x[2]})))))))
+                                            sort(unique(unlist(lapply(strsplit(out$req_title, split = " "), 
+                                                        function(x){x[2]}))))))
     out[order(out$req_title),]
     
   }


### PR DESCRIPTION
Fixing the requirement title in the coverage matrix for requirement names that are non-integers, such as "01" instead of "1". This is a quick fix. It would be even better if the actual requirement was used, as in the risk assessment matrix.